### PR TITLE
Added code to remove '$' and '%' from records before rendering the charts

### DIFF
--- a/js/visualization_entity_charts_steps.js
+++ b/js/visualization_entity_charts_steps.js
@@ -107,6 +107,16 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
         parent: self
       });
 
+      // Remove '$' and '%' signs from data
+      self.state.get('model').records.each(function(record) {
+        _.each(self.state.attributes.seriesFields, function(field) {
+          var fieldValue = record.get(field);
+          fieldValue = fieldValue.replace(/^\$/, '');
+          fieldValue = fieldValue.replace(/%$/, '');
+          record.set(field, fieldValue);
+        });
+      });
+
       // Controls available only for this graphType.
       self.extendedControls = new recline.View.nvd3[graphType + 'Controls']({
         model: self.state.get('model'),

--- a/js/visualization_entity_charts_view.js
+++ b/js/visualization_entity_charts_view.js
@@ -36,6 +36,17 @@
         var graph = null;
 
         dataset.fetch().done(function(dataset){
+
+          // Remove '$' and '%' signs from data
+          dataset.records.each(function(record) {
+            _.each(state.attributes.seriesFields, function(field) {
+              var fieldValue = record.get(field);
+              fieldValue = fieldValue.replace(/^\$/, '');
+              fieldValue = fieldValue.replace(/%$/, '');
+              record.set(field, fieldValue);
+            });
+          });
+
           dataset.queryState.set(state.get('queryState'));
           graph = new recline.View.nvd3[state.get('graphType')]({
             model: dataset,

--- a/js/visualization_entity_charts_view_multiple.js
+++ b/js/visualization_entity_charts_view_multiple.js
@@ -48,6 +48,17 @@
           model.url = cleanURL(model.url);
           dataset = new recline.Model.Dataset(model);
           dataset.fetch().done(function(dataset){
+
+            // Remove '$' and '%' signs from data
+            dataset.records.each(function(record) {
+              _.each(state.attributes.seriesFields, function(field) {
+                var fieldValue = record.get(field);
+                fieldValue = fieldValue.replace(/^\$/, '');
+                fieldValue = fieldValue.replace(/%$/, '');
+                record.set(field, fieldValue);
+              });
+            });
+
             dataset.queryState.set(state.get('queryState'));
             graph = new recline.View.nvd3[state.get('graphType')]({
               model: dataset,


### PR DESCRIPTION
This fixes this: https://github.com/NuCivic/ok_data/issues/50.

Basically, some datasets from Oklahoma contains some numeric values with '$' and '%' symbols that are breaking the charts. As we can't modify the datasets, we should alter the data when the chart is rendered.

I don't know if this should be merged into master because it's a very specific fix, but I think we can use this as a base in order to work out an optimal solution.
