### PR TITLE
Enables multiple graphs on the same page

### DIFF
--- a/js/visualization_entity_charts_view.js
+++ b/js/visualization_entity_charts_view.js
@@ -6,54 +6,65 @@
 (function ($) {
   Drupal.behaviors.VisualizationEntityChartsView = {
     attach: function (context) {
-      var isIframe = !$('.content').is(':visible');
-      var state = $('.field-name-field-ve-settings .field-item:eq(0)').text();
-      var $el;
-      var title;
-      var height;
-      var $body;
 
-      if(state){
-        state = new recline.Model.ObjectState(JSON.parse(state));
-        $body = $(document.body);
-        $window = $(window);
-        $body.removeClass('admin-menu');
-
+      var graphs = $('.graph');
+      $.each(graphs, function(key, graph){
+        var $el = '#' + $(graph).attr('id');
+        var state = $($el).siblings(".entity").find(".field-name-field-ve-settings .field-item:eq(0)").text();
         if($('#iframe-shell').length){
           $el = $('#iframe-shell');
-          if(state.get('showTitle')){
-            title = $el.find('h2 a').html();
-            $body.prepend('<h2 class="chartTitle">' + title + '</h2>');
-            height = getChartHeight(true);
-            resize();
-          } else {
-            height = getChartHeight(false);
-          }
-          state.set('height', height);
-          state.set('width', $window.width() - 10);
-          $window.on('resize', resize);
-        } else {
-          $el = $('#graph');
-          state.set('width', $('.field-name-field-ve-settings').width());
         }
+        createGraph(state, $el);
+      });
 
-        var model = state.get('source');
-        var graph = null;
-        model.url = cleanURL(model.url);
-        $.get(model.url).done(function(data){
-          data = data.replace(/(?:\r|\n)/g, '\r\n');
-          data = CSV.parse(data);
-          state.set('model', new recline.Model.Dataset({records: data}));
-          model = state.get('model');
-          model.queryState.set(state.get('queryState'));
-          graph = new recline.View.nvd3[state.get('graphType')]({
-            model: model,
-            state: state,
-            el: $el
+
+
+      function createGraph(state,$el) {
+        var isIframe = !$('.content').is(':visible');
+        var title;
+        var height;
+        var $body;
+
+        if(state){
+          state = new recline.Model.ObjectState(JSON.parse(state));
+          $body = $(document.body);
+          $window = $(window);
+          $body.removeClass('admin-menu');
+
+          if($('#iframe-shell').length){
+            if(state.get('showTitle')){
+              title = $el.find('h2 a').html();
+              $body.prepend('<h2 class="chartTitle">' + title + '</h2>');
+              height = getChartHeight(true);
+              resize();
+            } else {
+              height = getChartHeight(false);
+            }
+            state.set('height', height);
+            state.set('width', $window.width() - 10);
+            $window.on('resize', resize);
+          } else {
+            state.set('width', $($el).width());
+          }
+
+          var model = state.get('source');
+          var graph = null;
+          model.url = cleanURL(model.url);
+          $.get(model.url).done(function(data){
+            data = data.replace(/(?:\r|\n)/g, '\r\n');
+            data = CSV.parse(data);
+            state.set('model', new recline.Model.Dataset({records: data}));
+            model = state.get('model');
+            model.queryState.set(state.get('queryState'));
+            graph = new recline.View.nvd3[state.get('graphType')]({
+              model: model,
+              state: state,
+              el: $el
+            });
+            graph.render();
           });
-          graph.render();
-        });
-        
+
+        }
       }
       function cleanURL(url){
         var haveProtocol = new RegExp('^(?:[a-z]+:)?//', 'i');

--- a/visualization_entity_charts.module
+++ b/visualization_entity_charts.module
@@ -55,7 +55,7 @@ function visualization_entity_charts_attach_libraries(&$element) {
  */
 function visualization_entity_charts_entity_view($entity, $type, $view_mode, $langcode) {
   if ($type == 'visualization' && $entity->type == 've_chart') {
-    $entity->content['#suffix'] = '<div id="graph"></div>';
+    $entity->content['#suffix'] = '<div class="graph" data-id="' . $entity->id . '" id="graph-' . $entity->id . '"></div>';
     visualization_entity_charts_attach_libraries($entity->content);
     $entity->content['#attached']['css'][] = drupal_get_path('module', 'visualization_entity_charts') . '/css/ve_chart.css';
     drupal_add_js(drupal_get_path('module', 'visualization_entity_charts') . '/js/visualization_entity_charts_view.js', array('weight' => 101));
@@ -266,9 +266,11 @@ function visualization_entity_load_required_libraries(){
  * Implements hook_charts_visualization_entity_embed_render_alter().
  */
 function visualization_entity_charts_visualization_entity_embed_render_alter($vars) {
+  var_dump('wtf');
   $visualization = $vars['visualization'];
+  dpm($vars);
 
-  if (!empty($visualization) && $visualization->type === 've_chart' && $vars['conf']['local_source']) {
+  if (!empty($visualization) && $visualization->type === 've_chart') {
 
     // Load required libraries.
     visualization_entity_load_required_libraries();

--- a/visualization_entity_charts.module
+++ b/visualization_entity_charts.module
@@ -266,9 +266,7 @@ function visualization_entity_load_required_libraries(){
  * Implements hook_charts_visualization_entity_embed_render_alter().
  */
 function visualization_entity_charts_visualization_entity_embed_render_alter($vars) {
-  var_dump('wtf');
   $visualization = $vars['visualization'];
-  dpm($vars);
 
   if (!empty($visualization) && $visualization->type === 've_chart') {
 


### PR DESCRIPTION
## Description

You can't currently put two graphs on the same page UNLESS you use the iframe embed. This PR solves that by creating new instances for each graph and not using the same `#graph` id for each.
## User Story

``` yaml
As a site administrator
I want to create a view
That has more than one chart

As an editor
I would like to use panels
Two add two charts to the same page
```
## Acceptance Criteria

Create a view with multiple working charts.
## TODOs
- [ ] See if this breaks the iframe implementation yet
- [ ] Remove https://github.com/NuCivic/visualization_entity_charts/blob/master/js/visualization_entity_charts_view_multiple.js since it shouldn't be necessary
