### PR TITLE
NuCivic/ok_data#280 Fix resource/source field interaction

### DIFF
--- a/js/visualization_entity_charts.js
+++ b/js/visualization_entity_charts.js
@@ -58,6 +58,10 @@
         init();
       }
       if(state) {
+        // Hide existing resource field on all but step 1
+        if (state.attributes.step > 0) {
+          $("#field-uuid-resource-add-more-wrapper").hide();
+        }
         setActiveStep(state.get('step'));
       } else {
         setActiveStep(0);
@@ -92,6 +96,13 @@
 
         msv.on('multistep:change', function(e){
           setActiveStep(e.step);
+          // Hide existing resource field on all but step 1 (see line 61)
+          if (e.step > 0) {
+            $("#field-uuid-resource-add-more-wrapper").hide();
+          }
+          else {
+            $("#field-uuid-resource-add-more-wrapper").show();
+          }
         });
         msv.render();
 


### PR DESCRIPTION
@topicus @msolv 
issue: https://github.com/NuCivic/ok_data/issues/280

The **source** field only updates if you are on step one of the chart form. This commit hides the 'existing resource' field on all steps but the first one. The user will have to go back to the first step 'Load Data' to change the existing resource, and the source field will update as expected.
