### PR TITLE
NuCivic/ok_data#280 Fix form behavior when exisiting resource field i…

### DIFF
--- a/js/visualization_entity_charts.js
+++ b/js/visualization_entity_charts.js
@@ -107,19 +107,18 @@
         });
         var $resourceField = $('#edit-field-uuid-resource-und-0-target-uuid');
 
-        $resourceField.focus('autocompleteSelect', function(event, node) {
-          msv.gotoStep(0);
-          msv.render();
-          setActiveStep(0);
-        });
-
-        $resourceField.blur('autocompleteSelect', function(event, node) {
+        $resourceField.on('autocompleteSelect', function(event, node) {
           var re = /\[(.*?)\]/;
           var $sourceField = $('#control-chart-source');
           var uuid = re.exec($resourceField.val())[1];
-          $sourceField.val('/node/' + uuid + '/download');  
+          var url = '/node/' + uuid + '/download';
+          var source = {backend:'csv', url: url};
+          sharedObject.state.set('source', source);
+          $sourceField.val(url);
+          msv.gotoStep(0);
+          msv.render();
         });
-        
+
         sharedObject.state.on('change', function(){
           $('#edit-field-ve-settings-und-0-value').val(JSON.stringify(sharedObject.state.toJSON()));
         });

--- a/js/visualization_entity_charts.js
+++ b/js/visualization_entity_charts.js
@@ -107,12 +107,19 @@
         });
         var $resourceField = $('#edit-field-uuid-resource-und-0-target-uuid');
 
-        $resourceField.on('autocompleteSelect', function(event, node) {
+        $resourceField.focus('autocompleteSelect', function(event, node) {
+          msv.gotoStep(0);
+          msv.render();
+          setActiveStep(0);
+        });
+
+        $resourceField.blur('autocompleteSelect', function(event, node) {
           var re = /\[(.*?)\]/;
           var $sourceField = $('#control-chart-source');
           var uuid = re.exec($resourceField.val())[1];
-          $sourceField.val('/node/' + uuid + '/download');
+          $sourceField.val('/node/' + uuid + '/download');  
         });
+        
         sharedObject.state.on('change', function(){
           $('#edit-field-ve-settings-und-0-value').val(JSON.stringify(sharedObject.state.toJSON()));
         });


### PR DESCRIPTION
**Issue:** 
NuCivic/ok_data#280
The source field is not updated if the 'existing resource' field is changed on any other step but the first.

This PR updates  js/visualization_entity_charts.js so that changes to the existing resource field behaves the same as the file input field.

**Acceptance Criteria**
1. Log in as admin
2. Create a chart visualization.
3. Now edit the chart:
4. From the final step (Preview and adjust), click the 'Existing resource' field input, it should move you back to step 1 in the form (Load data).
5. Select a different resource.
6. The 'source' field should update to use the new resource
7. Click next, next, finish, and confirm the resource has changed.
